### PR TITLE
feat: allow multiple nodes in `k3d`

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,7 +117,6 @@ func advertise(ingresses []networkingv1.Ingress) error {
 				if ip == "" {
 					ip = lb.IP
 				}
-
 			} else {
 				return fmt.Errorf("lokus works only if all matching ingresses use the same loadbalancer")
 			}

--- a/main.go
+++ b/main.go
@@ -107,6 +107,8 @@ func advertise(ingresses []networkingv1.Ingress) error {
 		}
 		for _, lb := range ingress.Status.LoadBalancer.Ingress {
 
+			// Address has previously been set when there are multiple LB IPs,
+			// this is okay to proceed.
 			if ip == lb.IP {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -106,9 +106,17 @@ func advertise(ingresses []networkingv1.Ingress) error {
 			}
 		}
 		for _, lb := range ingress.Status.LoadBalancer.Ingress {
-			if ip == "" {
-				ip = lb.IP
-			} else if ip != lb.IP {
+
+			if ip == lb.IP {
+				continue
+			}
+
+			if ip != lb.IP {
+				if ip == "" {
+					ip = lb.IP
+				}
+
+			} else {
 				return fmt.Errorf("lokus works only if all matching ingresses use the same loadbalancer")
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func deduplicate(data []string) []string {
 	return result
 }
 
-func generateHosts(ingresses []networkingv1.Ingress) ([]string, string, error) {
+func generateHosts(ingresses []networkingv1.Ingress) (hosts []string, loadBalancerIP string, err error) {
 	var (
 		ip    string
 		names []string

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/strings/slices"
+)
+
+func TestMultipleLoadBalancerIPs(t *testing.T) {
+
+	fakeIngress := []networkingv1.Ingress{
+
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake",
+				Namespace: "test",
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Ingress",
+			},
+			Spec: networkingv1.IngressSpec{
+				Rules: []networkingv1.IngressRule{
+					networkingv1.IngressRule{
+						Host: "fake.local",
+					}},
+			},
+			Status: networkingv1.IngressStatus{
+				LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+					Ingress: []networkingv1.IngressLoadBalancerIngress{
+						networkingv1.IngressLoadBalancerIngress{IP: "192.168.48.4"},
+						networkingv1.IngressLoadBalancerIngress{IP: "192.168.48.5"},
+					},
+				},
+			},
+		},
+	}
+
+	names, ip, err := generateHosts(fakeIngress)
+	if err != nil {
+		t.Fatalf("expected no error, got %+v", err)
+	}
+	fmt.Println(names, ip)
+	expectedNames := []string{"fake.local"}
+	expectedIp := "192.168.48.4" // The first address we find
+
+	if !slices.Equal(names, expectedNames) {
+		t.Fatalf("expected: %v, got: %v", expectedNames, names)
+	}
+
+	if ip != expectedIp {
+		t.Fatalf("expected: %v, got: %v", expectedIp, ip)
+	}
+
+}

--- a/main_test.go
+++ b/main_test.go
@@ -43,7 +43,6 @@ func TestMultipleLoadBalancerIPs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %+v", err)
 	}
-	fmt.Println(names, ip)
 	expectedNames := []string{"fake.local"}
 	expectedIp := "192.168.48.4" // The first address we find
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 
 	networkingv1 "k8s.io/api/networking/v1"


### PR DESCRIPTION
With multiple LB IPs we run into the situation where they do not match and `lokus` errors out.

We can have multiple LB IPs from having more than 1 node in our `k3d` cluster as there is a `svclb-traefik` `DaemonSet` running in the `kube-system` namespace.
