### PR TITLE
Handle multiple ingresses with multiple load balancer IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Export .local ingress hostnames via mDNS
 
 Designed to be used with https://k3d.io/v5.6.0/ or other local kuberneteses that offer routable loadbalancers from the host.
 
+Turns out it also works with GKE and its default ingress controller!
+
 ## Install
 
 Homebrew (macos/linux):

--- a/main_test.go
+++ b/main_test.go
@@ -8,49 +8,162 @@ import (
 	"k8s.io/utils/strings/slices"
 )
 
-func TestMultipleLoadBalancerIPs(t *testing.T) {
-
-	fakeIngress := []networkingv1.Ingress{
-
+func TestGenerateHosts(t *testing.T) {
+	type expectedHost struct {
+		names []string
+		ip    string
+	}
+	tests := []struct {
+		name          string
+		fakeIngresses []networkingv1.Ingress
+		expectedHosts []expectedHost
+	}{
 		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "fake",
-				Namespace: "test",
-			},
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Ingress",
-			},
-			Spec: networkingv1.IngressSpec{
-				Rules: []networkingv1.IngressRule{
-					networkingv1.IngressRule{
-						Host: "fake.local",
-					}},
-			},
-			Status: networkingv1.IngressStatus{
-				LoadBalancer: networkingv1.IngressLoadBalancerStatus{
-					Ingress: []networkingv1.IngressLoadBalancerIngress{
-						networkingv1.IngressLoadBalancerIngress{IP: "192.168.48.4"},
-						networkingv1.IngressLoadBalancerIngress{IP: "192.168.48.5"},
+			name: "MultipleLoadBalancerIPs",
+			fakeIngresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake",
+						Namespace: "test",
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Ingress",
+					},
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "fake.local",
+							},
+						},
+					},
+					Status: networkingv1.IngressStatus{
+						LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+							Ingress: []networkingv1.IngressLoadBalancerIngress{
+								{IP: "192.168.48.4"},
+								{IP: "192.168.48.5"},
+							},
+						},
 					},
 				},
+			},
+			expectedHosts: []expectedHost{
+				{names: []string{"fake.local"}, ip: "192.168.48.4"},
+			},
+		},
+		{
+			name: "MultipleHosts",
+			fakeIngresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "fake",
+						Namespace: "test",
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Ingress",
+					},
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "one.local",
+							},
+							{
+								Host: "two.local",
+							},
+						},
+					},
+					Status: networkingv1.IngressStatus{
+						LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+							Ingress: []networkingv1.IngressLoadBalancerIngress{
+								{IP: "192.168.48.4"},
+							},
+						},
+					},
+				},
+			},
+			expectedHosts: []expectedHost{
+				{names: []string{"one.local", "two.local"}, ip: "192.168.48.4"},
+			},
+		},
+		{
+			name: "MultipleIngresses",
+			fakeIngresses: []networkingv1.Ingress{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "one",
+						Namespace: "test",
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Ingress",
+					},
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "one.local",
+							},
+						},
+					},
+					Status: networkingv1.IngressStatus{
+						LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+							Ingress: []networkingv1.IngressLoadBalancerIngress{
+								{IP: "192.168.48.4"},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "two",
+						Namespace: "test",
+					},
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "Ingress",
+					},
+					Spec: networkingv1.IngressSpec{
+						Rules: []networkingv1.IngressRule{
+							{
+								Host: "two.local",
+							},
+						},
+					},
+					Status: networkingv1.IngressStatus{
+						LoadBalancer: networkingv1.IngressLoadBalancerStatus{
+							Ingress: []networkingv1.IngressLoadBalancerIngress{
+								{IP: "192.168.48.4"},
+							},
+						},
+					},
+				},
+			},
+			expectedHosts: []expectedHost{
+				{names: []string{"one.local", "two.local"}, ip: "192.168.48.4"},
 			},
 		},
 	}
 
-	names, ip, err := generateHosts(fakeIngress)
-	if err != nil {
-		t.Fatalf("expected no error, got %+v", err)
-	}
-	expectedNames := []string{"fake.local"}
-	expectedIp := "192.168.48.4" // The first address we find
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hosts, err := generateHosts(tt.fakeIngresses)
+			if err != nil {
+				t.Fatalf("expected no error, got %+v", err)
+			}
 
-	if !slices.Equal(names, expectedNames) {
-		t.Fatalf("expected: %v, got: %v", expectedNames, names)
-	}
+			if got, want := len(hosts), len(tt.expectedHosts); got != want {
+				t.Fatalf("got: %v, want: %v", got, want)
+			}
 
-	if ip != expectedIp {
-		t.Fatalf("expected: %v, got: %v", expectedIp, ip)
-	}
+			for i, host := range hosts {
+				if got, want := host.names, tt.expectedHosts[i].names; !slices.Equal(got, want) {
+					t.Fatalf("got: %v, want: %v", got, want)
+				}
 
+				if got, want := host.ip, tt.expectedHosts[i].ip; got != want {
+					t.Fatalf("got: %v, want: %v", got, want)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
(I wrote the code myself but then I used openAI integration with https://zed.dev/  (not copilot, just plain chatgpt integration) to refactor the tests to use table driven tests and to adapt the tests to the multiple hostname/ip result of `generateHosts`; it worked on first try with very little hand holding )